### PR TITLE
Allow tile sizes to be multiples of 16

### DIFF
--- a/src/fmha-pipeline/fmha_consumer.h
+++ b/src/fmha-pipeline/fmha_consumer.h
@@ -59,5 +59,15 @@ fmhaForwardConsumer(Gemm1Type const *Q, Gemm1Type const *K, Gemm2Type const *V,
   auto tOrP = make_tensor(tSrSPrec.data(), tOrPLayout);
   warpgroup_fence_operand(tSrS);
   // Issue GEMM-II.
+#if 0
+  if (cute::thread0()) {
+        print("\n");
+        print(tOrPLayout);
+        print("\n");
+        print(tOrV.layout());
+        print("\n");
+   }
+#endif
+
   cfk::gemm(tiledMma1, tOrP, tOrV, tOrO);
 }

--- a/src/fmha-pipeline/fmha_forward.cu
+++ b/src/fmha-pipeline/fmha_forward.cu
@@ -63,10 +63,8 @@ template <typename PrecType, int DIM> constexpr auto getSmemLayoutK() {
 		return GMMA::Layout_K_SW32_Atom<PrecType>{};
 	} else if constexpr (headSizeBytes == 64) {
 		return GMMA::Layout_K_SW64_Atom<PrecType>{};
-	}  else if constexpr (headSizeBytes == 128) {
-		return GMMA::Layout_K_SW128_Atom<PrecType>{};
 	} else {
-		return GMMA::Layout_K_INTER_Atom<PrecType>{};
+		return GMMA::Layout_K_SW128_Atom<PrecType>{};
 	}
 }
 
@@ -78,10 +76,8 @@ template <typename PrecType, int DIM> constexpr auto getSmemLayoutMN() {
 		return GMMA::Layout_MN_SW32_Atom<PrecType>{};
 	} else if constexpr (headSizeBytes == 64) {
 		return GMMA::Layout_MN_SW64_Atom<PrecType>{};
-	} else if constexpr (headSizeBytes == 128) {
-		return GMMA::Layout_MN_SW128_Atom<PrecType>{};
 	} else {
-		return GMMA::Layout_MN_INTER_Atom<PrecType>{};
+		return GMMA::Layout_MN_SW128_Atom<PrecType>{};
 	}
 }
 

--- a/src/fmha-pipeline/fmha_forward.cu
+++ b/src/fmha-pipeline/fmha_forward.cu
@@ -378,8 +378,7 @@ void fmhaForwardDevice(int SEQLEN, int KEYLEN, int NUMHEADS, int BATCH,
         tmak, tileShapeK, gmemLayoutK, smemLayoutK, tensorS, tileShapeS,
         gmemLayoutS, smemLayoutS, nTilesOfK, tensorV, tmaV, tileShapeV,
         gmemLayoutV, smemLayoutV, smemLayoutVt, tensorO, tmaO, tileShapeO,
-        gmemLayoutO, smemLayoutO, miOut, sPrimeOut, gmemLayoutMi, scale);
-     cudaMemset ( tensorO, 0, 4);
+        gmemLayoutO, smemLayoutO, miOut, sPrimeOut, gmemLayoutMi, scale);     
   }
 }
 


### PR DESCRIPTION
This pull request fixes a problem with tile sizes below 64 when they otherwise should be allowed. In practice though, it's not expected that these small tile sizes will lead to improved performance except in some edge cases with small sequence length.