### PR TITLE
tma_load_mbar argument fix

### DIFF
--- a/src/cute-gemm-tma-gma/gemm.cu
+++ b/src/cute-gemm-tma-gma/gemm.cu
@@ -308,6 +308,8 @@ __global__ static void gemm_device(
     constexpr int kTmaTransactionBytes =
         size(sA) * sizeof_bits_v<TA> / 8 + size(sB) * sizeof_bits_v<TB> / 8;
 
+    cfk::barrierInit(tma_load_mbar[0], 1);
+
     cfk::copy(tAgA(_, stage), tBgB(_, stage), tAsA(_, 0), tBsB(_, 0),
               tma_load_a, tma_load_b, tma_load_mbar[0], mcast_mask_a,
               mcast_mask_b);

--- a/src/cute-gemm-tma-gma/gemm.cu
+++ b/src/cute-gemm-tma-gma/gemm.cu
@@ -309,7 +309,7 @@ __global__ static void gemm_device(
         size(sA) * sizeof_bits_v<TA> / 8 + size(sB) * sizeof_bits_v<TB> / 8;
 
     cfk::copy(tAgA(_, stage), tBgB(_, stage), tAsA(_, 0), tBsB(_, 0),
-              tma_load_a, tma_load_b, tma_load_mbar, mcast_mask_a,
+              tma_load_a, tma_load_b, tma_load_mbar[0], mcast_mask_a,
               mcast_mask_b);
     cfk::gemm(tiled_mma, tCrA, tCrB, tCrC);
 


### PR DESCRIPTION
`tma_load_mbar` --> `tma_load_mbar[0]` to pass `uint64_t &` instead of `uint64_t *`

I got the error attached below when using the following version of `nvcc`:
```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Fri_Jun_14_16:34:21_PDT_2024
Cuda compilation tools, release 12.6, V12.6.20
Build cuda_12.6.r12.6/compiler.34431801_0
```

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ee0629c6-9a2b-454e-844f-fec115304157">

